### PR TITLE
Optimize benchmarking script, Docker images, and Micronaut config

### DIFF
--- a/java_web_frameworks/start.py
+++ b/java_web_frameworks/start.py
@@ -231,9 +231,12 @@ def run():
     if DEBUG:
         rprint(f"Results: {results}")
 
-    with open("results.json", "w") as f:
+    results_dir = os.path.join(os.getcwd(), "benchmark-results")
+    os.makedirs(results_dir, exist_ok=True)
+    results_path = os.path.join(results_dir, "results.json")
+    with open(results_path, "w") as f:
         json.dump(results, f, indent=2)
-    rprint("Results saved to results.json")
+    rprint(f"Results saved to {results_path}")
 
     table = Table(title="Results")
 

--- a/java_web_frameworks/start.py
+++ b/java_web_frameworks/start.py
@@ -21,19 +21,19 @@ def get_value_from_time(output: str, pattern: re.Pattern):
     return re.search(pattern, output, flags=re.RegexFlag.MULTILINE).group(1)
 
 
-def process_container_output(output: bytearray):
-    output = output.decode("utf-8")
+def process_container_output(output: bytes):
+    decoded = output.decode("utf-8")
 
-    user_time = get_value_from_time(output, r"User time \(seconds\): ([0-9.]+)")
-    system_time = get_value_from_time(output, r"System time \(seconds\): ([0-9.]+)")
-    cpu_percent = get_value_from_time(output, r"Percent of CPU this job got: (\d+)%")
+    user_time = get_value_from_time(decoded, r"User time \(seconds\): ([0-9.]+)")
+    system_time = get_value_from_time(decoded, r"System time \(seconds\): ([0-9.]+)")
+    cpu_percent = get_value_from_time(decoded, r"Percent of CPU this job got: (\d+)%")
     time_used = get_value_from_time(
-        output, r"Elapsed \(wall clock\) time \(h:mm:ss or m:ss\): ([0-9ms. ]+)"
+        decoded, r"Elapsed \(wall clock\) time \(h:mm:ss or m:ss\): ([0-9ms. ]+)"
     )
 
     memory_used = re.search(
         r"Maximum resident set size \(kbytes\): ([0-9]+)",
-        output,
+        decoded,
         flags=re.RegexFlag.MULTILINE,
     ).group(1)
 
@@ -43,29 +43,29 @@ def process_container_output(output: bytearray):
         cpu_percent,
         time_used,
         int(memory_used),
-        round(get_logged_time(output, "STARTING JAVA") / 1_000_000),
-        get_logged_time(output, "JAVA STARTED"),
-        get_logged_time(output, "FRAMEWORK STARTED"),
-        get_logged_time(output, "START FRAMEWORK SHUTDOWN"),
-        round(get_logged_time(output, "JAVA STOPPED") / 1_000_000),
+        round(get_logged_time(decoded, "STARTING JAVA") / 1_000_000),
+        get_logged_time(decoded, "JAVA STARTED"),
+        get_logged_time(decoded, "FRAMEWORK STARTED"),
+        get_logged_time(decoded, "START FRAMEWORK SHUTDOWN"),
+        round(get_logged_time(decoded, "JAVA STOPPED") / 1_000_000),
     )
 
 
-def process_dive_output(output: bytearray):
-    output = output.decode("utf-8")
-    output = output.split("{", maxsplit=1)[1]
-    output = "{" + output
-    json_data = json.loads(output)
+def process_dive_output(output: bytes):
+    decoded = output.decode("utf-8")
+    decoded = decoded.split("{", maxsplit=1)[1]
+    decoded = "{" + decoded
+    json_data = json.loads(decoded)
     sizeBytes = json_data["image"]["sizeBytes"]
     efficiencyScore = json_data["image"]["efficiencyScore"]
     return sizeBytes, efficiencyScore
 
 
-def run_maven(project: str, type: str):
+def run_maven(project: str, build_type: str):
     rprint("Running Maven...")
     work_dir = os.path.join(os.getcwd(), "projects", project)
 
-    docker_image = f"java-web-frameworks/{project}_{type}"
+    docker_image = f"java-web-frameworks/{project}_{build_type}"
 
     rprint(
         "----------------------------------------------------------------------------------"
@@ -78,7 +78,7 @@ def run_maven(project: str, type: str):
         "docker",
         "build",
         "--file",
-        f"../Dockerfile.{type}",
+        f"../Dockerfile.{build_type}",
         "--tag",
         docker_image,
     ]
@@ -100,12 +100,12 @@ def run_maven(project: str, type: str):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
+    build_output, _ = process.communicate()
     if DEBUG:
-        for c in iter(lambda: process.stdout.read(1), b""):
-            sys.stdout.buffer.write(c)
-    retval = process.wait()
+        sys.stdout.buffer.write(build_output)
+    retval = process.returncode
     if retval != 0:
-        raise Exception(f"Error: {retval}")
+        raise Exception(f"Docker build failed (exit {retval}):\n{build_output.decode('utf-8', errors='replace')}")
     end = time.time_ns()
     build_duration = round((end - start) / 1_000_000)
     rprint(f"Docker build returned {retval} in {build_duration}ms")
@@ -118,12 +118,7 @@ def run_maven(project: str, type: str):
     command = [
         "docker",
         "run",
-        "--interactive",
-        "--tty",
         "--rm",
-        # "--memory=256m",
-        # "--memory-swap=256m",
-        # "--cpus=1",
         docker_image,
     ]
 
@@ -134,14 +129,12 @@ def run_maven(project: str, type: str):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
-    output = bytearray()
-    for c in iter(lambda: process.stdout.read(1), b""):
-        if DEBUG:
-            sys.stdout.buffer.write(c)
-        output += c
-    retval = process.wait()
+    output, _ = process.communicate()
+    if DEBUG:
+        sys.stdout.buffer.write(output)
+    retval = process.returncode
     if retval != 0:
-        raise Exception(f"Error: {retval}")
+        raise Exception(f"Docker run failed (exit {retval}):\n{output.decode('utf-8', errors='replace')}")
 
     (
         user_time,
@@ -177,22 +170,20 @@ def run_maven(project: str, type: str):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
-    output = bytearray()
-    for c in iter(lambda: process.stdout.read(1), b""):
-        if DEBUG:
-            sys.stdout.buffer.write(c)
-        output += c
-    retval = process.wait()
+    dive_output, _ = process.communicate()
+    if DEBUG:
+        sys.stdout.buffer.write(dive_output)
+    retval = process.returncode
     if retval != 0:
-        raise Exception(f"Error: {retval}")
-    sizeBytes, efficiencyScore = process_dive_output(output)
+        raise Exception(f"Dive failed (exit {retval}):\n{dive_output.decode('utf-8', errors='replace')}")
+    sizeBytes, efficiencyScore = process_dive_output(dive_output)
 
     rprint(
         "----------------------------------------------------------------------------------"
     )
 
     return (
-        f"{project}_{type}",
+        f"{project}_{build_type}",
         {
             "build_duration": build_duration,
             "user_time": user_time,
@@ -239,6 +230,10 @@ def run():
     )
     if DEBUG:
         rprint(f"Results: {results}")
+
+    with open("results.json", "w") as f:
+        json.dump(results, f, indent=2)
+    rprint("Results saved to results.json")
 
     table = Table(title="Results")
 

--- a/projects/Dockerfile.native
+++ b/projects/Dockerfile.native
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.m2 ./mvnw --batch-mode package -Pnative -Ds
 
 FROM alpine as runner
 
-RUN apk add --no-cache coreutils libc6-compat
+RUN apk add --no-cache coreutils
 
 COPY entrypoint-native.sh /entrypoint.sh
 COPY --from=builder /home/app/target/app /app

--- a/projects/micronaut-maven/.dockerignore
+++ b/projects/micronaut-maven/.dockerignore
@@ -1,0 +1,4 @@
+target/
+*.iml
+.idea/
+.git/

--- a/projects/micronaut-maven/pom.xml
+++ b/projects/micronaut-maven/pom.xml
@@ -19,7 +19,7 @@
         <jdk.version>21</jdk.version>
         <release.version>21</release.version>
 
-        <micronaut.version>4.3.7</micronaut.version>
+        <micronaut.version>4.10.8</micronaut.version>
         <micronaut.aot.enabled>false</micronaut.aot.enabled>
         <micronaut.aot.packageName>com.tyutyutyu.jwf.aot.generated</micronaut.aot.packageName>
         <micronaut.runtime>netty</micronaut.runtime>

--- a/projects/quarkus-maven/.dockerignore
+++ b/projects/quarkus-maven/.dockerignore
@@ -1,0 +1,4 @@
+target/
+*.iml
+.idea/
+.git/

--- a/projects/spring-boot-maven/.dockerignore
+++ b/projects/spring-boot-maven/.dockerignore
@@ -1,0 +1,4 @@
+target/
+*.iml
+.idea/
+.git/


### PR DESCRIPTION
- start.py: replace byte-by-byte subprocess reads with process.communicate()
  to eliminate O(n) syscall overhead and fix potential stdout buffer deadlocks
- start.py: remove --interactive --tty flags from docker run (unnecessary
  for automated benchmark runs and allocates a pseudo-TTY uselessly)
- start.py: rename 'type' parameter to 'build_type' to avoid shadowing the
  Python built-in
- start.py: add JSON results export to results.json for persistent storage
- start.py: include subprocess output in error messages for easier debugging
- Dockerfile.native: remove libc6-compat from Alpine runner stage; binaries
  are statically linked (--static --libc=musl) and don't need glibc compat
- Add .dockerignore to all three projects to exclude target/, .idea/, *.iml
  and .git/ from the Docker build context, reducing context transfer size
- micronaut-maven/pom.xml: align micronaut.version (4.3.7 → 4.10.8) with
  the micronaut-parent version already bumped by Renovate to 4.10.8

https://claude.ai/code/session_01UoPhX5Yvzxd4ytmrTGuuJV